### PR TITLE
Add a config option for specifying worlds that players cannot store pearls in 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>com.devotedmc</groupId>
 	<artifactId>ExilePearl</artifactId>
 	<packaging>jar</packaging>
-	<version>0.5.8-SNAPSHOT</version>
+	<version>0.5.9-SNAPSHOT</version>
 	<name>ExilePearl</name>
 	<url>https://github.com/DevotedMC/ExilePearl</url>
 
@@ -119,6 +119,12 @@
 			<groupId>net.elseland.xikage</groupId>
 			<artifactId>MythicMobs</artifactId>
 			<version>2.5.1</version>
+			<scope>provided</scope>
+		</dependency>
+		<dependency>
+			<groupId>io.lumine.xikage</groupId>
+			<artifactId>MythicLib</artifactId>
+			<version>0.0.1-SNAPSHOT</version>
 			<scope>provided</scope>
 		</dependency>
 

--- a/src/main/java/com/devotedmc/ExilePearl/Lang.java
+++ b/src/main/java/com/devotedmc/ExilePearl/Lang.java
@@ -30,7 +30,7 @@ public class Lang
 	
 	public static final String groupUnknown = "<i>That group doesn't exist.";
 	public static final String groupNoChatPermission = "<i>You don't have permission to chat in that group.";
-	public static final String groupAlreadyBcasting = "<i>You're already broadcasting to that group.";
+	public static final String groupStoppedBcasting = "<g>You've stopped broadcasting your pearl location to group <c>%s";
 	public static final String groupNowBcasting = "<g>You're now broadcasting your pearl location to group <c>%s";
 	public static final String groupPearlBroadcast = "<gray>[%s]<i>The pearl of <c>%s <i>is held by <a>%s <n>[%d %d %d %s]";
 	

--- a/src/main/java/com/devotedmc/ExilePearl/command/CmdPearlBroadcast.java
+++ b/src/main/java/com/devotedmc/ExilePearl/command/CmdPearlBroadcast.java
@@ -49,9 +49,11 @@ public class CmdPearlBroadcast extends PearlCommand {
 					msg(Lang.groupNoChatPermission);
 					return;
 				}
-				
+
+				//If they are already broadcasting to group then remove the listener for that group
 				if (pearl.isBroadcastingTo(g)) {
-					msg(Lang.groupAlreadyBcasting);
+					pearl.removeBroadcastListener(new NLGroupBroadcastListener(g));
+					msg(Lang.groupStoppedBcasting, g.getName());
 					return;
 				}
 				

--- a/src/main/java/com/devotedmc/ExilePearl/config/PearlConfig.java
+++ b/src/main/java/com/devotedmc/ExilePearl/config/PearlConfig.java
@@ -14,7 +14,13 @@ public interface PearlConfig extends MySqlConfig, DocumentConfig {
 	 * @return The storage type
 	 */
 	StorageType getStorageType();
-	
+
+	/**
+	 * Gets a set of worlds that pearls can not be stored in
+	 * @return a set of names of worlds pearls can't be stored in
+	 */
+	Set<String> getDisallowedWorlds();
+
 	/**
 	 * Gets the pearl decay minute interval
 	 * @return the pearl decay minute interval

--- a/src/main/java/com/devotedmc/ExilePearl/core/CoreExilePearl.java
+++ b/src/main/java/com/devotedmc/ExilePearl/core/CoreExilePearl.java
@@ -397,7 +397,6 @@ final class CoreExilePearl implements ExilePearl {
 	/**
 	 * Verifies the holder of a pearl
 	 * @param holder The holder to check
-	 * @param feedback The feedback string
 	 * @return true if the pearl was found in a valid location
 	 */
 	private HolderVerifyResult verifyHolder(PearlHolder holder) {
@@ -473,12 +472,7 @@ final class CoreExilePearl implements ExilePearl {
 
 	@Override
 	public void removeBroadcastListener(Object o) {
-		for(BroadcastListener b : bcastListeners) {
-			if (b.contains(o)) {
-				bcastListeners.remove(b);
-				return;
-			}
-		}
+		bcastListeners.remove(o);
 	}
 
 

--- a/src/main/java/com/devotedmc/ExilePearl/core/CorePearlConfig.java
+++ b/src/main/java/com/devotedmc/ExilePearl/core/CorePearlConfig.java
@@ -180,6 +180,14 @@ final class CorePearlConfig implements DocumentConfig, PearlConfig {
 	}
 
 	@Override
+	public Set<String> getDisallowedWorlds() {
+		HashSet<String> worlds = new HashSet<>();
+		for(String str : doc.getStringList("rules.disallowed_worlds"))
+			worlds.add(str);
+		return worlds;
+	}
+
+	@Override
 	public List<String> getProtectedAnimals() {
 		return doc.getStringList("rules.protected_mobs");
 	}

--- a/src/main/java/com/devotedmc/ExilePearl/core/CorePearlManager.java
+++ b/src/main/java/com/devotedmc/ExilePearl/core/CorePearlManager.java
@@ -256,6 +256,7 @@ final class CorePearlManager implements PearlManager {
 
 		final Collection<ExilePearl> pearls = getPearls();
 		final int decayAmount = pearlApi.getPearlConfig().getPearlHealthDecayAmount();
+		final Set<String> disallowedWorlds = pearlApi.getPearlConfig().getDisallowedWorlds();
 		final HashSet<ExilePearl> pearlsToFree = new HashSet<ExilePearl>();
 
 		// Iterate through all the pearls and reduce the health
@@ -265,7 +266,13 @@ final class CorePearlManager implements PearlManager {
 			if (pearl.getFreedOffline()) {
 				continue;
 			}
-			
+
+			PearlHolder holder = pearl.getHolder();
+			if(holder.isBlock() && disallowedWorlds.contains(holder.getLocation().getWorld().getName())) {
+				pearlApi.log("Freeing pearl for player %s because the pearl is stored in disallowed world %s.", pearl.getPlayerName(),holder.getLocation().getWorld().getName());
+				pearlsToFree.add(pearl);
+			}
+
 			pearl.setHealth(pearl.getHealth() - decayAmount);
 			
 			if (pearl.getHealth() == 0) {

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -29,7 +29,7 @@
 # * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * #
 #                                PEARL SETTINGS                               #
 # * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * #
-# 
+#
 # pearls.autofree_worldborder
 #  - When true, pearls that are outside world-border will be freed during a 
 #    decay operation
@@ -192,7 +192,10 @@
 # rules.protected_mobs
 #  - Mobs that are protected when rules.kill_mobs is set to false
 # 
-# 
+# rules.disallowed_worlds
+#  - Worlds that pearls are not allowed to be stored in
+#
+#
 # Start Config
 storage:
   type: 0
@@ -267,3 +270,5 @@ rules:
   - Cow
   - Pig
   - Horse
+  disallowed_worlds:
+


### PR DESCRIPTION
Added an option into that config for blacklisting a set of worlds. The blacklisted worlds will not allow pearls to be stored in them. This will take effect every pearl decay and will automatically free any pearls held in blocks in the blacklisted worlds.