### PR TITLE
Adding removal of exile bed spawn on combat death

### DIFF
--- a/src/main/java/com/devotedmc/ExilePearl/ExileRule.java
+++ b/src/main/java/com/devotedmc/ExilePearl/ExileRule.java
@@ -29,6 +29,7 @@ public enum ExileRule {
 	DRINK_BREWS("DRINK_BREWS", "Drink Brewery Brews"),
 	MILK_COWS("MILK_COWS", "Milk Cows using Bucket"),
 	FILL_CAULDRON("FILL_CAULDRON", "Fill Cauldron using Bucket")
+	SPAWN_RESET("SPAWN_RESET", "Reset exiled players bed on death by player")
 	;
 	
 	private final String text;
@@ -92,6 +93,8 @@ public enum ExileRule {
 			return USE_ANVIL;
 		case "PLACE_TNT":
 			return PLACE_TNT;
+		case "SPAWN_RESET":
+			return SPAWN_RESET;
 		
 		default:
 			return null;

--- a/src/main/java/com/devotedmc/ExilePearl/ExileRule.java
+++ b/src/main/java/com/devotedmc/ExilePearl/ExileRule.java
@@ -28,7 +28,7 @@ public enum ExileRule {
 	PLACE_TNT("PLACE_TNT", "use TNT"),
 	DRINK_BREWS("DRINK_BREWS", "Drink Brewery Brews"),
 	MILK_COWS("MILK_COWS", "Milk Cows using Bucket"),
-	FILL_CAULDRON("FILL_CAULDRON", "Fill Cauldron using Bucket")
+	FILL_CAULDRON("FILL_CAULDRON", "Fill Cauldron using Bucket"),
 	SPAWN_RESET("SPAWN_RESET", "Reset exiled players bed on death by player")
 	;
 	

--- a/src/main/java/com/devotedmc/ExilePearl/core/CorePearlConfig.java
+++ b/src/main/java/com/devotedmc/ExilePearl/core/CorePearlConfig.java
@@ -295,7 +295,10 @@ final class CorePearlConfig implements DocumentConfig, PearlConfig {
 			
 		case MILK_COWS:
 			return doc.getBoolean("rules.milk_cows", true);
-			
+		
+		case SPAWN_RESET:
+			return doc.getBoolean("rules.spawn_reset", false);
+				
 		default:
 			return false;
 		}
@@ -403,6 +406,9 @@ final class CorePearlConfig implements DocumentConfig, PearlConfig {
 		case MILK_COWS:
 			doc.append("rules.milk_cows", value);
 			break;
+		
+		case SPAWN_RESET:
+			doc.append("rules.spawn_reset", value);
 			
 		default:
 			break;

--- a/src/main/java/com/devotedmc/ExilePearl/listener/PlayerListener.java
+++ b/src/main/java/com/devotedmc/ExilePearl/listener/PlayerListener.java
@@ -578,7 +578,10 @@ public class PlayerListener implements Listener, Configurable {
 		}
 		
 		if (killer != null) {
-			
+			//Reset bed of exiled player if killer is not null
+			if (pearlApi.getPearlConfig().canPerform(ExileRule.SPAWN_RESET)) {
+				pearl.getPlayer().setBedSpawnLocation(null,true);
+			}
 			// Notify other damagers if they were not awarded the pearl
 			for(Player damager : damagers) {
 				if (damager != killer) {

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -135,6 +135,9 @@
 # rules.use_bed
 #  - When false, exiled players can't use beds
 # 
+# rules.spawn_reset
+#  - When true, resets the bed of an exiled player if killed by another player
+# 
 # rules.use_bucket
 #  - When false, exiled players can't empty buckets or move them to other inventories
 #
@@ -281,6 +284,7 @@ rules:
   pearl_radius: 1000
   ignite: false
   use_bed: false
+  spawn_reset: false
   use_bucket: false
   fill_bucket: false
   milk_cows: true


### PR DESCRIPTION
If an exile player dies by a killer, then this new rule will remove their bed spawn and force a random spawn. Probably needs a test and also committing to 1.14 branch